### PR TITLE
chore: add issue draft files (.github/ISSUES)

### DIFF
--- a/.github/ISSUES/01-add-persistence.md
+++ b/.github/ISSUES/01-add-persistence.md
@@ -1,0 +1,14 @@
+Title: Add persistent storage (SQLite) and migrations
+
+Problem
+- The app currently uses an in-memory activities store; data is lost on restart.
+
+Proposal
+- Add SQLite-based persistence (using SQLAlchemy or the standard `sqlite3`), add lightweight migration or bootstrap scripts, and include an updated `requirements.txt` for local development. Keep the current JSON API and frontend unchanged where possible.
+
+Acceptance criteria
+- Activities and participant sign-ups persist across restarts.
+- Provide a migration / bootstrap step and update the README with setup instructions.
+- Add a minimal smoke test or manual verification steps to confirm persistence.
+
+Labels: enhancement

--- a/.github/ISSUES/02-add-user-accounts.md
+++ b/.github/ISSUES/02-add-user-accounts.md
@@ -1,0 +1,14 @@
+Title: Add user accounts and membership pages
+
+Problem
+- No user accounts or profile management; membership flows are not implemented.
+
+Proposal
+- Implement sign-up/login endpoints, per-user profile endpoints (view/edit/delete), and add simple UI or API docs for membership flows. Use secure password storage and session or token-based auth.
+
+Acceptance criteria
+- Endpoints to create users, login (session or token), view/edit profile, and delete account.
+- Frontend: simple membership page or API examples for clients.
+- Basic input validation and tests or manual verification steps.
+
+Labels: enhancement

--- a/.github/ISSUES/03-fix-security.md
+++ b/.github/ISSUES/03-fix-security.md
@@ -1,0 +1,14 @@
+Title: Fix security issues — hash passwords & use parameterized queries
+
+Problem
+- Storing plaintext passwords and building SQL via string interpolation is insecure and vulnerable to SQL injection.
+
+Proposal
+- Add password hashing (Werkzeug or bcrypt) and update the database layer to use parameterized queries or an ORM (SQLAlchemy). Audit existing DB calls and replace unsafe patterns.
+
+Acceptance criteria
+- Passwords are stored hashed; login verifies with hash checks.
+- No raw string interpolation in SQL statements; queries use parameters.
+- README updated with security notes and migration steps if needed.
+
+Labels: security

--- a/.github/ISSUES/04-fix-change-name-bug.md
+++ b/.github/ISSUES/04-fix-change-name-bug.md
@@ -1,0 +1,12 @@
+Title: Fix `change_name` logic bug in external reference / sample (optional)
+
+Problem
+- A comparison found a bug in the external sample `event-signup-python-mysql` where the `change_name` database update uses the wrong variable for `lastName`.
+
+Proposal
+- If we adapt code from the external sample, correct the update to use the correct variable and add a unit or manual test to prevent regressions.
+
+Acceptance criteria
+- Fix applied (if relevant) and a short test or validation added.
+
+Labels: bug

--- a/.github/ISSUES/05-add-schema-and-bootstrap.md
+++ b/.github/ISSUES/05-add-schema-and-bootstrap.md
@@ -1,0 +1,13 @@
+Title: Add database schema & sample data + bootstrap script
+
+Problem
+- There are no local DB bootstrap scripts or sample data to speed development and testing.
+
+Proposal
+- Provide a `schema.sql` or lightweight migration, and a sample data loader or script that inserts example activities and participants for local development.
+
+Acceptance criteria
+- `schema.sql` or migrations included and documented.
+- A `scripts/bootstrap_db.sh` or Python script provided to load sample data.
+
+Labels: enhancement

--- a/.github/ISSUES/06-frontend-ux-improvements.md
+++ b/.github/ISSUES/06-frontend-ux-improvements.md
@@ -1,0 +1,13 @@
+Title: Improve frontend UX — success messages and activity limits
+
+Problem
+- Frontend works but could show clearer confirmations and enforce activity capacity server-side.
+
+Proposal
+- Add clearer success/error messages, disable signup when an activity is full, and return `spots_left` from server API. Ensure server enforces `max_participants`.
+
+Acceptance criteria
+- Frontend shows clear success/error messages for signup/unregister.
+- Server returns spots-left and enforces `max_participants`.
+
+Labels: enhancement


### PR DESCRIPTION
This PR adds six issue-draft markdown files under `.github/ISSUES/` so maintainers can review and convert them into GitHub Issues. The drafts cover persistence, user accounts, security fixes, schema/bootstrap, frontend UX, and a small bug fix note.

Files added:
- .github/ISSUES/01-add-persistence.md
- .github/ISSUES/02-add-user-accounts.md
- .github/ISSUES/03-fix-security.md
- .github/ISSUES/04-fix-change-name-bug.md
- .github/ISSUES/05-add-schema-and-bootstrap.md
- .github/ISSUES/06-frontend-ux-improvements.md

If you'd like, I can also convert these drafts to real issues — provide a PAT or we can proceed manually from this PR.